### PR TITLE
App isolation and update to Debian 11 (using latest apt Python 3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,28 @@
-FROM python:3.7-alpine
+# requestshogger.Dockerfile
+FROM debian:11-slim AS build
 
-ADD requirements.txt .
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv && \
+    python3 -m venv /venv && \
+    /venv/bin/pip3 install --upgrade pip
 
-RUN pip install -r requirements.txt
+# Build the virtualenv as a separate step
+# It will only re-execute this step when requirements.txt changes
+FROM build AS build-venv
 
-ADD hogger .
+COPY requirements.txt /requirements.txt
+RUN /venv/bin/pip3 install --disable-pip-version-check -U -r /requirements.txt
+
+# Copy the virtualenv into a distroless image
+FROM gcr.io/distroless/python3-debian11
+COPY --from=build-venv /venv /venv
+COPY hogger /app/hogger
+WORKDIR /app
 
 # Don't bind to a specific address
 ENV HOGGER_HOST="0.0.0.0"
-ENTRYPOINT ["python", "reqhogger.py"]
+
+# Executing Hogger
+ENTRYPOINT ["/venv/bin/python", "/app/hogger/reqhogger.py"]
 
 EXPOSE 8910

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 * **Danilo Martins** - *Initial work* - [Mawkee](https://github.com/mawkee)
 * **Deepak Vashist** - *Test scaffolding and initial tests* - [Deepak](https://github.com/deepakvashist)
+* **Evandro Arruda** - *Dockerfile update to Debian 11 and app isolation* - [ecarruda](https://github.com/ecarruda)
 
 ## License
 


### PR DESCRIPTION
Application isolation and update to Debian 11 (using latest apt Python 3)
